### PR TITLE
[HOTFIX] Refine Mindmap Branch

### DIFF
--- a/app/services/modification_service.py
+++ b/app/services/modification_service.py
@@ -274,12 +274,6 @@ class ModificationService:
                         f"Mindmap Topic: {request.context.mindmapTitle}. "
                     )
 
-                # Educational metadata
-                if request.context.grade:
-                    tree_context += f"Grade Level: {request.context.grade}. "
-                if request.context.subject:
-                    tree_context += f"Subject: {request.context.subject}. "
-
                 # Hierarchy context
                 if request.context.rootNodeContent:
                     tree_context += (
@@ -316,8 +310,6 @@ class ModificationService:
 
             # Prepare grade level text for prompt
             grade_level = ""
-            if request.context and request.context.grade:
-                grade_level = f" for {request.context.grade}"
 
             prompt = self._render(
                 prompt_key,
@@ -464,12 +456,6 @@ class ModificationService:
                         f"Mindmap Topic: {request.context.mindmapTitle}. "
                     )
 
-                # Educational metadata
-                if request.context.grade:
-                    tree_context += f"Grade Level: {request.context.grade}. "
-                if request.context.subject:
-                    tree_context += f"Subject: {request.context.subject}. "
-
                 # Hierarchy context
                 if request.context.rootNodeContent:
                     tree_context += (
@@ -511,18 +497,13 @@ class ModificationService:
             )
             prompt_key = f"modification.mindmap.{operation}_branch"
 
-            # Prepare grade level text for prompt
-            grade_level = ""
-            if request.context and request.context.grade:
-                grade_level = f" for {request.context.grade}"
-
             prompt = self._render(
                 prompt_key,
                 {
                     "nodes_json": nodes_json,
                     "tree_context": tree_context,
                     "instruction": request.instruction,
-                    "grade_level": grade_level,
+                    "grade_level": "",
                 },
             )
 


### PR DESCRIPTION
This pull request simplifies the handling of educational metadata in the `modification_service.py` by removing the inclusion of grade level and subject information from the mindmap context and prompt generation logic. This streamlines the code and ensures that grade and subject are no longer added to the prompt context or passed as variables.

**Metadata removal:**
* Removed the addition of grade level and subject information to the `tree_context` string in both `refine_mindmap_node` and `refine_mindmap_branch` methods. [[1]](diffhunk://#diff-affda72fbff7524510e00c9adab539809d8f95b486731c6336404571b6fb25a9L277-L282) [[2]](diffhunk://#diff-affda72fbff7524510e00c9adab539809d8f95b486731c6336404571b6fb25a9L467-L472)

**Prompt generation update:**
* Eliminated the logic that prepares and injects the `grade_level` variable into the prompt, ensuring it is now always an empty string in both methods. [[1]](diffhunk://#diff-affda72fbff7524510e00c9adab539809d8f95b486731c6336404571b6fb25a9L319-L320) [[2]](diffhunk://#diff-affda72fbff7524510e00c9adab539809d8f95b486731c6336404571b6fb25a9L514-R506)